### PR TITLE
Linux Sensors support

### DIFF
--- a/.fake
+++ b/.fake
@@ -1,2 +1,4 @@
 Bump for Runtime Manager Changes
 Bump for Runtime Manager Changes
+Bump for Link Repository Changes
+

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ out/
 nodes.json
 .pids
 .rtm_stub
+.packages

--- a/dslink.json
+++ b/dslink.json
@@ -25,6 +25,14 @@
     "offset_memory_disk_cache": {
       "type": "bool",
       "default": true
+    },
+    "lmsensors_raw_mode": {
+      "type": "bool",
+      "default": false
+    },
+    "lmsensors_fahrenheit_mode": {
+      "type": "bool",
+      "default": false
     }
   }
 }

--- a/example/sensor-parser.dart
+++ b/example/sensor-parser.dart
@@ -1,0 +1,88 @@
+import "package:dslink_system/lm_sensors.dart";
+
+const String SensorInputA = """
+lm92-i2c-0-48
+Adapter: SMBus I801 adapter at f000
+temp1:        +14.0°C  (low  = +14.0°C, hyst = +28.0°C)
+                       (high = +14.0°C, hyst =  +0.0°C)
+                       (crit = +14.0°C, hyst =  +0.0°C)
+
+asus-isa-0000
+Adapter: ISA adapter
+cpu_fan:        0 RPM
+
+coretemp-isa-0000
+Adapter: ISA adapter
+Package id 0:  +26.0°C  (high = +80.0°C, crit = +100.0°C)
+Core 0:        +25.0°C  (high = +80.0°C, crit = +100.0°C)
+Core 1:        +23.0°C  (high = +80.0°C, crit = +100.0°C)
+Core 2:        +22.0°C  (high = +80.0°C, crit = +100.0°C)
+Core 3:        +22.0°C  (high = +80.0°C, crit = +100.0°C)
+""";
+
+const String SensorInputB = """
+lm92-i2c-0-48
+Adapter: SMBus I801 adapter at f000
+temp1:
+  temp1_input: 14.000
+  temp1_max: 14.000
+  temp1_max_hyst: 0.000
+  temp1_min: 14.000
+  temp1_crit: 14.000
+  temp1_crit_hyst: 0.000
+  temp1_min_hyst: 28.000
+  temp1_max_alarm: 0.000
+  temp1_min_alarm: 0.000
+  temp1_crit_alarm: 0.000
+
+asus-isa-0000
+Adapter: ISA adapter
+cpu_fan:
+  fan1_input: 0.000
+
+coretemp-isa-0000
+Adapter: ISA adapter
+Package id 0:
+  temp1_input: 25.000
+  temp1_max: 80.000
+  temp1_crit: 100.000
+  temp1_crit_alarm: 0.000
+Core 0:
+  temp2_input: 21.000
+  temp2_max: 80.000
+  temp2_crit: 100.000
+  temp2_crit_alarm: 0.000
+Core 1:
+  temp3_input: 23.000
+  temp3_max: 80.000
+  temp3_crit: 100.000
+  temp3_crit_alarm: 0.000
+Core 2:
+  temp4_input: 21.000
+  temp4_max: 80.000
+  temp4_crit: 100.000
+  temp4_crit_alarm: 0.000
+Core 3:
+  temp5_input: 22.000
+  temp5_max: 80.000
+  temp5_crit: 100.000
+  temp5_crit_alarm: 0.000
+""";
+
+main() async {
+  test(SensorInputA);
+  test(SensorInputB);
+}
+
+void test(String input) {
+  var data = parseSensorsOutput(input);
+
+  for (var bus in data.keys) {
+    var sensors = data[bus];
+
+    print("${bus}:");
+    for (var key in sensors.keys) {
+      print("  ${key}: ${sensors[key]}");
+    }
+  }
+}

--- a/example/sensors.dart
+++ b/example/sensors.dart
@@ -1,7 +1,7 @@
 import "package:dslink_system/lm_sensors.dart";
 
 main() async {
-  var data = await getLmSensorData();
+  var data = await getLmSensorData(graceful: false);
 
   for (var bus in data.keys) {
     var sensors = data[bus];

--- a/example/sensors.dart
+++ b/example/sensors.dart
@@ -1,0 +1,14 @@
+import "package:dslink_system/lm_sensors.dart";
+
+main() async {
+  var data = await getLmSensorData();
+
+  for (var bus in data.keys) {
+    var sensors = data[bus];
+
+    print("${bus}:");
+    for (var key in sensors.keys) {
+      print("  ${key}: ${sensors[key]}");
+    }
+  }
+}

--- a/lib/lm_sensors.dart
+++ b/lib/lm_sensors.dart
@@ -5,6 +5,8 @@ import "dart:io";
 
 import "utils.dart" as util;
 
+import "package:dslink/utils.dart" show logger;
+
 final RegExp rawValuePattern = new RegExp(r"[+-.0-9]+");
 
 class SensorValue {
@@ -111,10 +113,11 @@ Future<Map<String, Map<String, SensorValue>>> getLmSensorData({
     }
 
     return parseSensorsOutput(result.stdout.toString());
-  } catch (e) {
+  } catch (e, stack) {
     if (!graceful) {
       rethrow;
     }
+    logger.fine("Fetching Linux sensor data failed.", e, stack);
     return <String, Map<String, SensorValue>>{};
   }
 }

--- a/lib/lm_sensors.dart
+++ b/lib/lm_sensors.dart
@@ -1,0 +1,95 @@
+library dslink.system.lm_sensors;
+
+import "dart:async";
+import "dart:io";
+
+import "utils.dart" as util;
+
+final RegExp rawValuePattern = new RegExp(r"[+-.0-9]+");
+
+class SensorValue {
+  final double value;
+  final String unit;
+
+  SensorValue(this.value, [this.unit]);
+
+  @override
+  String toString() => "${value}${unit == null ? '' : ' ' + unit}";
+}
+
+Map<String, Map<String, SensorValue>> parseSensorsOutput(String input) {
+  var out = <String, Map<String, SensorValue>>{};
+  var lines = input.split("\n");
+
+  String currentSection;
+
+  var values = <String, SensorValue>{};
+  for (var line in lines) {
+    if (line.isEmpty) {
+      continue;
+    }
+
+    if (line.contains(":")) {
+      if (
+        (line.startsWith("  ") ||
+        !line.startsWith("Adapter")) &&
+        currentSection != null) {
+        var name = line.substring(
+          line.startsWith(" ") ? line.indexOf(" ") : 0,
+          line.indexOf(":")
+        );
+
+        var range = line.lastIndexOf("(");
+        var valueContent = line.substring(
+          line.indexOf(":") + 1,
+          range == -1 ? null : range
+        ).trim();
+
+        var rawValue = rawValuePattern.firstMatch(valueContent).group(0);
+        var unitsLeft = valueContent.replaceAll(rawValue, "").trim();
+        
+        values[name] = new SensorValue(
+          double.parse(rawValue),
+          unitsLeft.isEmpty ? null : unitsLeft
+        );
+      }
+    } else {
+      values = <String, SensorValue>{};
+      currentSection = line;
+      out[currentSection] = values;
+    }
+  }
+
+  return out;
+}
+
+Future<bool> isLmSensorsAvailable() async {
+  if (!Platform.isLinux) {
+    return false;
+  }
+
+  var path = await util.findExecutable("sensors");
+  return path != null;
+}
+
+Future<Map<String, Map<String, SensorValue>>> getLmSensorData({
+  bool fahrenheit: false,
+  bool graceful: true
+}) async {
+  try {
+    var path = await util.findExecutable("sensors");
+
+    var result = await Process.run(path, fahrenheit ? const ["-f"] : const []);
+
+    if (result.exitCode != 0) {
+      return {};
+    }
+
+    return parseSensorsOutput(result.stdout.toString());
+  } catch (e) {
+    if (!graceful) {
+      rethrow;
+    }
+    return <String, Map<String, SensorValue>>{};
+  }
+}


### PR DESCRIPTION
This adds support for lm_sensors on Linux.
This processes the output from the following command:
```bash
$ sensors
coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +32.0°C  (high = +80.0°C, crit = +100.0°C)
Core 0:        +26.0°C  (high = +80.0°C, crit = +100.0°C)
Core 1:        +29.0°C  (high = +80.0°C, crit = +100.0°C)
Core 2:        +26.0°C  (high = +80.0°C, crit = +100.0°C)
Core 3:        +27.0°C  (high = +80.0°C, crit = +100.0°C)

radeon-pci-0200
Adapter: PCI adapter
temp1:        +59.0°C  (crit = +120.0°C, hyst = +90.0°C)

asus-isa-0000
Adapter: ISA adapter
cpu_fan:        0 RPM
```

It is then turned into a DSA node structure. This is extremely useful for fans, temperature sensors, etc.

Most machines will now see per-CPU temperatures, provided that lm_sensors is installed.
